### PR TITLE
new URL for rextester.com API Forwader

### DIFF
--- a/Proxy.md
+++ b/Proxy.md
@@ -59,7 +59,7 @@ var result = null;
 var error  = false;
 
 $.ajax ({
-    url: "https://test.ess-project.ovgu.de/rundotnet/api",
+    url: "https://rextesterfwd.ess-project.ovgu.de/rundotnet/api",
     type: "POST",
     async: false,
     data: { "LanguageChoice": "@0",
@@ -113,7 +113,7 @@ for executing code snippets in 45 differentprogramming languages by using the
 getting mixed-content-errors, we have created a proxy for testing purposes,
 through which all requests get passed:
 
-https://test.ess-project.ovgu.de/rundotnet/api
+https://rextesterfwd.ess-project.ovgu.de/rundotnet/api
 
 If you are on github, then see the rendered version [here](https://liascript.github.io/course/?https://raw.githubusercontent.com/liaScript/rextester_template/master/Proxy.md)
 


### PR DESCRIPTION
changed URLs to https://rextesterfwd.ess-project.ovgu.de/rundotnet/api